### PR TITLE
Revert "[OPS-1019] Split into separate derivations"

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,0 @@
-(import ./. { }).shell


### PR DESCRIPTION
Reverts serokell/hackage-search#1

It broke my workflow. `ghcid backend/Search.hs` no longer works (there are missing packages). 