### PR TITLE
Remove trailing '/' from nginx proxyPass config to fix query encoding

### DIFF
--- a/service.nix
+++ b/service.nix
@@ -94,8 +94,8 @@ in {
     services.nginx.virtualHosts.hackage-search = {
       locations."/".proxyPass =
         if ! isNull cfg.socket
-        then "http://unix:${cfg.socket}:/"
-        else "http://localhost:${toString cfg.port}/";
+        then "http://unix:${cfg.socket}:"
+        else "http://localhost:${toString cfg.port}";
 
       locations."/static/fonts/".alias = "${cfg.package}/fonts/";
     };


### PR DESCRIPTION
With trailing slash nginx decodes urlencoded query, for example instead
of '/abc%2Fdef' it passes '/abc/def' to the backend, which breaks the
search. Removing trailing slash makes nginx pass the query verbatim.

Fixes #17