### PR TITLE
CI: print full logs for `nix flake check`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: Check Nix flake
     commands:
-      - nix-shell --run 'nix flake check'
+      - nix-shell --run 'nix flake check -L'
 
   - wait
 


### PR DESCRIPTION
Without '-L' nix only prints logs on failure, and only the last 10
lines of them