### PR TITLE
[SIO-281] Update canonical url to absolute path

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="favicon.svg">
     <title> Hackage Search </title>
-    <link rel="canonical" href="/">
+    <link rel="canonical" href="https://hackage-search.serokell.io/">
     <style></style>
   </head>
   <body>


### PR DESCRIPTION
For SEO purposes marketing prefers the canonical URL to be absolute rather than relative.