### PR TITLE
[Chore] Don't use old 'nix run' command

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,6 @@ steps:
 
   - label: Deploy
     commands:
-      - nix run -f. inputs.deploy-rs.defaultPackage.x86_64-linux
+      - nix shell -f. inputs.deploy-rs.defaultPackage.x86_64-linux
           -c deploy
     branches: "release"


### PR DESCRIPTION
Problem: 'nix run' interface has changed with flake addition. However, CI pipeline in this repo still uses the old 'nix run' for which we keep a workaround on our build servers.

Solution: Use 'nix shell' instead.