### PR TITLE
[Chore] Add systemd unit restart policy

### DIFF
--- a/service.nix
+++ b/service.nix
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+# SPDX-FileCopyrightText: 2020-2023 Serokell <https://serokell.io/>
 #
 # SPDX-License-Identifier: MPL-2.0
 
@@ -45,9 +45,15 @@ in {
         startAt = "daily";
         script = ''hackage-download --hackage "$CACHE_DIRECTORY"'';
 
+        startLimitBurst = mkDefault 5;
+        startLimitIntervalSec = mkDefault 300;
+
         serviceConfig = {
           DynamicUser = true;
           User = "hackage-search";
+
+          Restart = mkDefault "on-failure";
+          RestartSec = mkDefault 10;
 
           CacheDirectory = "hackage-search";
           WorkingDirectory = "/var/cache/hackage-search";
@@ -72,9 +78,15 @@ in {
             hackage-search ${serve} --frontend "${cfg.package}/html" --hackage "$CACHE_DIRECTORY"
           '';
 
+        startLimitBurst = mkDefault 5;
+        startLimitIntervalSec = mkDefault 300;
+
         serviceConfig = {
           DynamicUser = true;
           User = "hackage-search";
+
+          Restart = mkDefault "on-failure";
+          RestartSec = mkDefault 10;
 
           ExecStartPost =
             if isNull cfg.socket


### PR DESCRIPTION
Problem: By default, systemd services generated from the NixOS system configuration don't attempt to restart on failure since Restart=no. However, in some cases, running processes can fail for unclear reasons, and the simplest way to bring the failed service back to life is to restart it. Instead, currently, the service will fail and trigger an alert without attempting to restart.

Solution: Add default values for startLimitBurst, startLimitIntervalSec, Restart, and RestartSec.