### PR TITLE
[OPS-1161] Harden systemd service

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
       }))
 
     {
-      module = import ./service.nix;
+      module = import ./service.nix { inherit serokell-nix; };
 
       # Deployment expressions
       deploy.magicRollback = false;

--- a/service.nix
+++ b/service.nix
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: 2020-2023 Serokell <https://serokell.io/>
 #
 # SPDX-License-Identifier: MPL-2.0
-
+{ serokell-nix }:
 { config, lib, pkgs, ... }:
 with lib;
 let
   cfg = config.services.hackage-search;
+  inherit (serokell-nix.lib.systemd) hardeningProfiles withHardeningProfile;
 in {
   options.services.hackage-search = {
     enable = mkEnableOption "Hackage search server";
@@ -81,7 +82,7 @@ in {
         startLimitBurst = mkDefault 5;
         startLimitIntervalSec = mkDefault 300;
 
-        serviceConfig = {
+        serviceConfig = withHardeningProfile hardeningProfiles.backend {
           DynamicUser = true;
           User = "hackage-search";
 


### PR DESCRIPTION
Problem: We want to harden the security of our systemd services.

Solution: Use the hardening profile defined in serokell.nix.