### PR TITLE
[GHC-121] Revert prometheus

### DIFF
--- a/backend/Search.hs
+++ b/backend/Search.hs
@@ -20,6 +20,7 @@ import qualified Data.ByteString.Builder as ByteString.Builder
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import qualified Data.Map as Map
 import Data.Monoid (Endo(..))
+import Data.Streaming.Network (bindPath)
 import qualified Data.Streaming.Network
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -37,7 +38,7 @@ import Servant ((:<|>)(..), Proxy(..), StreamGet, serveDirectoryFileServer)
 import Servant.API ((:>), Capture, CaptureAll, Get, NewlineFraming, PlainText, Raw, ToSourceIO(..))
 import Servant.HTML.Blaze (HTML)
 import Servant.Prometheus (meters, monitorServant)
-import Servant.Prometheus.Export (MetricsApi, serveMetrics)
+import Servant.Prometheus.Export (WithMetrics, withMetrics)
 import Servant.Server (Application, Server, err400, serve)
 import Servant.Types.SourceT (StepT(..), fromStepT)
 import System.FilePath ((</>))
@@ -59,8 +60,6 @@ data Config =
   }
 
 type HackageSearchAPI =
-    MetricsApi
-  :<|>
     "rg" :> Capture "pattern" String :> StreamGet NewlineFraming PlainText RgLineHandle
   :<|>
     "viewfile" :> CaptureAll "segments" String :> Get '[HTML] H.Html
@@ -69,6 +68,10 @@ type HackageSearchAPI =
 
 hackageSearchAPI :: Proxy HackageSearchAPI
 hackageSearchAPI = Proxy
+
+-- | Proxy for 'HackageSearchAPI' wih additional metrics.
+metricsApiProxy :: Proxy (WithMetrics HackageSearchAPI)
+metricsApiProxy = Proxy
 
 data RgLineHandle =
   RgLineHandle
@@ -124,7 +127,7 @@ every next result.
 
 hackageSearchServer :: Config -> Server HackageSearchAPI
 hackageSearchServer config =
-  serveMetrics :<|> searchH :<|> viewfileH :<|> frontendH
+  searchH :<|> viewfileH :<|> frontendH
   where
     searchH q = liftIO (rgSearch config q)
     viewfileH q = do
@@ -226,9 +229,9 @@ main = do
     Opt.execParser $
       Opt.info (configOptP <**> Opt.helper)
         (Opt.fullDesc <> Opt.header "Hackage Search")
-  mtrs <- register $ meters hackageSearchAPI
-  runServer configBindTarget . monitorServant mtrs . serve hackageSearchAPI $
-    hackageSearchServer config
+  mtrs <- register $ meters metricsApiProxy
+  runServer configBindTarget . monitorServant mtrs . serve metricsApiProxy .
+    withMetrics hackageSearchAPI $ hackageSearchServer config
 
 data BindTarget
   = BindOnPort Int

--- a/backend/Search.hs
+++ b/backend/Search.hs
@@ -4,51 +4,40 @@
 
 module Main (main) where
 
-import Control.Applicative ((<|>), (<**>))
+import System.IO
+import System.IO.Error
+import Control.Applicative
+import Control.Monad
 import Control.Concurrent (threadDelay)
+import Servant
+import Servant.Types.SourceT
+import Servant.HTML.Blaze (HTML)
+import Network.Wai.Handler.Warp
+import Data.Monoid
+import qualified Network.Socket
+import qualified Data.Streaming.Network
+import qualified Options.Applicative as Opt
+import System.Process
 import Control.DeepSeq (rnf)
 import Control.Exception hiding (Handler)
-import Control.Monad (forM_, guard)
-import Control.Monad.Except (throwError)
-import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
-import qualified Data.Aeson as JSON
-import qualified Data.Aeson.Encoding.Internal as JSON (list, pairStr)
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Maybe
+import Data.Text (Text)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
-import qualified Data.ByteString.Builder as ByteString.Builder
-import qualified Data.ByteString.Lazy as ByteString.Lazy
-import qualified Data.Map as Map
-import Data.Monoid (Endo(..))
-import Data.Streaming.Network (bindPath)
-import qualified Data.Streaming.Network
-import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text
+import qualified Data.Aeson as JSON
+import qualified Data.Aeson.Encoding.Internal as JSON (pairStr, list)
+import qualified Data.ByteString.Builder as ByteString.Builder
+import qualified Data.ByteString.Lazy as ByteString.Lazy
+import System.FilePath ((</>))
+import qualified System.FilePath as FilePath
 import qualified Distribution.Package as Cabal
 import qualified Distribution.Parsec as Cabal
 import qualified Distribution.Pretty as Cabal
-import qualified Network.Socket
-import Network.Wai.Handler.Warp (defaultSettings, run, runSettingsSocket)
-import qualified Options.Applicative as Opt
-import Prometheus (register)
-import Prometheus.Metric.GHC (ghcMetrics)
-import Servant ((:<|>)(..), Proxy(..), StreamGet, serveDirectoryFileServer)
-import Servant.API ((:>), Capture, CaptureAll, Get, NewlineFraming, PlainText, Raw, ToSourceIO(..))
-import Servant.HTML.Blaze (HTML)
-import Servant.Prometheus (meters, monitorServant)
-import Servant.Prometheus.Export (WithMetrics, withMetrics)
-import Servant.Server (Application, Server, err400, serve)
-import Servant.Types.SourceT (StepT(..), fromStepT)
-import System.FilePath ((</>))
-import qualified System.FilePath as FilePath
-import System.IO (Handle, hClose, hIsEOF, readFile)
-import System.IO.Error (isDoesNotExistError)
-import System.Process
-  ( ProcessHandle, StdStream(..), createProcess, cwd, proc, std_err, std_in,  std_out
-  , terminateProcess
-  )
+import qualified Data.Map as Map
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as H.A
 
@@ -68,10 +57,6 @@ type HackageSearchAPI =
 
 hackageSearchAPI :: Proxy HackageSearchAPI
 hackageSearchAPI = Proxy
-
--- | Proxy for 'HackageSearchAPI' wih additional metrics.
-metricsApiProxy :: Proxy (WithMetrics HackageSearchAPI)
-metricsApiProxy = Proxy
 
 data RgLineHandle =
   RgLineHandle
@@ -224,14 +209,11 @@ configOptP = do
 
 main :: IO ()
 main = do
-  register ghcMetrics
   config@Config{configBindTarget} <-
     Opt.execParser $
       Opt.info (configOptP <**> Opt.helper)
         (Opt.fullDesc <> Opt.header "Hackage Search")
-  mtrs <- register $ meters metricsApiProxy
-  runServer configBindTarget . monitorServant mtrs . serve metricsApiProxy .
-    withMetrics hackageSearchAPI $ hackageSearchServer config
+  runServer configBindTarget (serve hackageSearchAPI (hackageSearchServer config))
 
 data BindTarget
   = BindOnPort Int

--- a/flake.lock
+++ b/flake.lock
@@ -431,8 +431,7 @@
           "nixpkgs"
         ],
         "serokell-nix": "serokell-nix",
-        "serokell-website": "serokell-website",
-        "servant-prometheus": "servant-prometheus"
+        "serokell-website": "serokell-website"
       }
     },
     "serokell-nix": {
@@ -499,22 +498,6 @@
       "original": {
         "type": "git",
         "url": "ssh://git@github.com/serokell/serokell-website"
-      }
-    },
-    "servant-prometheus": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607950552,
-        "narHash": "sha256-Y7B/0pfcmfeAWs0f1A5wuNTRSa/YN8MMlxl3jI+YfQI=",
-        "owner": "serokell",
-        "repo": "servant-prometheus",
-        "rev": "bb6b2fa789be01b0994130dea7fe35db92362447",
-        "type": "github"
-      },
-      "original": {
-        "owner": "serokell",
-        "repo": "servant-prometheus",
-        "type": "github"
       }
     },
     "utils": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,14 +14,9 @@
 
     deploy-rs.url = "github:serokell/deploy-rs";
     deploy-rs.inputs.nixpkgs.follows = "nixpkgs";
-
-    servant-prometheus = {
-      url = "github:serokell/servant-prometheus";
-      flake = false;
-    };
   };
 
-  outputs = { self, nixpkgs, serokell-nix, flake-utils, deploy-rs, servant-prometheus, ... }@inputs:
+  outputs = { self, nixpkgs, serokell-nix, flake-utils, deploy-rs, ... }@inputs:
     let
       inherit (nixpkgs.lib) recursiveUpdate makeLibraryPath;
       inherit (builtins) mapAttrs;
@@ -29,7 +24,7 @@
     recursiveUpdate (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system}.extend serokell-nix.overlay;
-        p = import ./package.nix { inherit pkgs; servant-prometheus = import servant-prometheus { nixpkgs = pkgs; }; };
+        p = import ./package.nix { inherit pkgs; };
       in {
         defaultPackage = self.packages.${system}.hackage-search;
         packages.hackage-search = pkgs.buildEnv {

--- a/package.nix
+++ b/package.nix
@@ -1,5 +1,4 @@
 { pkgs
-, servant-prometheus
 , hc ? "ghc884"
 }:
 
@@ -17,14 +16,11 @@ let
       p.servant-server
       p.servant-blaze
       p.http-client-tls
-      p.prometheus-client
-      p.prometheus-metrics-ghc
       p.split
       p.tar
       p.unix
       p.uuid
       p.unagi-chan
-      servant-prometheus
     ]);
 
   backendInputs = [


### PR DESCRIPTION
This reverts the metrics added in #16. Reasons:

* `servant-prometheus` is not actively maintained
* it's easier to collect them at the HTTP proxy level than in the backend