### PR TITLE
[Chore] Remove dependency between hackage-search and hackage-download

### DIFF
--- a/service.nix
+++ b/service.nix
@@ -65,7 +65,7 @@ in {
       hackage-search = rec {
         wantedBy = [ "multi-user.target" ];
 
-        requires = [ "hackage-download.service" ];
+        requires = [ "network-online.target" ];
         after = requires;
 
         path = with pkgs; [ ripgrep cfg.package ];


### PR DESCRIPTION
Problem: The services are designed to be independent and only share the common data directory.

Solution: Remove 'Requires' and 'After' dependencies on 'hackage-download' for 'hackage-search' service