### PR TITLE
[OPS-1548] Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -288,11 +288,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1727447169,
-        "narHash": "sha256-3KyjMPUKHkiWhwR91J1YchF6zb6gvckCAY1jOE+ne0U=",
+        "lastModified": 1762286984,
+        "narHash": "sha256-9I2H9x5We6Pl+DBYHjR1s3UT8wgwcpAH03kn9CqtdQc=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "aa07eb05537d4cd025e2310397a6adcedfe72c76",
+        "rev": "9c870f63e28ec1e83305f7f6cb73c941e699f74f",
         "type": "github"
       },
       "original": {
@@ -489,11 +489,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -2045,11 +2045,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726646111,
-        "narHash": "sha256-/3AvN4QMz/tajuU5rA2MBecUQ51Qgo73KTQT+skS1uE=",
+        "lastModified": 1763123146,
+        "narHash": "sha256-z3sUbrs+1h9tYgZ/9ULFIJxTzkzUAQ9iN79TZ44dgmQ=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "4fc18e4ca848c9a5b402e48d4b30155965cfce60",
+        "rev": "dfd11acd410519387b8dcda3f625fab067b1c92e",
         "type": "github"
       },
       "original": {
@@ -2794,11 +2794,11 @@
         "weeder-src": "weeder-src"
       },
       "locked": {
-        "lastModified": 1740125565,
-        "narHash": "sha256-qTtZeIkG2ZyeXoNt9wuRRbcRyCLMEFkagwsLqB8Bn6A=",
+        "lastModified": 1765406432,
+        "narHash": "sha256-BS8URBx5I//SnspvrnAuJAqb+0mOArbR73lEgRTH4i0=",
         "owner": "serokell",
         "repo": "serokell.nix",
-        "rev": "f8cd23e1da7a63c390c64e18921c29953bd033db",
+        "rev": "5a004a5e06b93ab1ba2cec1c421ed999bd8db0f3",
         "type": "github"
       },
       "original": {
@@ -3146,11 +3146,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2855,15 +2855,16 @@
     "servant-prometheus": {
       "flake": false,
       "locked": {
-        "lastModified": 1742455243,
-        "narHash": "sha256-cP8hPh0sZwxpsiJcCm1Jm/5jm/Q8PTCEAXlp9TOfKBw=",
+        "lastModified": 1766025840,
+        "narHash": "sha256-sD6OvYiFmumVsvLcmadkjOmRwb01xfGgx1bRc49XA3c=",
         "owner": "serokell",
         "repo": "servant-prometheus",
-        "rev": "df05bd7afbc6f7dd4ec8cd979ce3a6ed5d1afb5f",
+        "rev": "b4437efc1b9d8724899c68b2386d70ccc7af2871",
         "type": "github"
       },
       "original": {
         "owner": "serokell",
+        "ref": "sereja/ops-1548-relax-warp-bound",
         "repo": "servant-prometheus",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2855,16 +2855,15 @@
     "servant-prometheus": {
       "flake": false,
       "locked": {
-        "lastModified": 1766025840,
+        "lastModified": 1766140294,
         "narHash": "sha256-sD6OvYiFmumVsvLcmadkjOmRwb01xfGgx1bRc49XA3c=",
         "owner": "serokell",
         "repo": "servant-prometheus",
-        "rev": "b4437efc1b9d8724899c68b2386d70ccc7af2871",
+        "rev": "830f397967626732b4ce7fd6fd56f97ac9df266e",
         "type": "github"
       },
       "original": {
         "owner": "serokell",
-        "ref": "sereja/ops-1548-relax-warp-bound",
         "repo": "servant-prometheus",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
     deploy-rs.inputs.nixpkgs.follows = "nixpkgs";
 
     servant-prometheus = {
-      url = "github:serokell/servant-prometheus/sereja/ops-1548-relax-warp-bound";
+      url = "github:serokell/servant-prometheus";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
     deploy-rs.inputs.nixpkgs.follows = "nixpkgs";
 
     servant-prometheus = {
-      url = "github:serokell/servant-prometheus";
+      url = "github:serokell/servant-prometheus/sereja/ops-1548-relax-warp-bound";
       flake = false;
     };
   };


### PR DESCRIPTION
Problem: We're repinning our nixpkgs fork, and want propagate the changes to all our projects.

Solution: Update flake.lock.

warning: updating lock file "/home/sereja/Code/work/hackage-search/flake.lock": • Updated input 'deploy-rs':
    'github:serokell/deploy-rs/aa07eb05537d4cd025e2310397a6adcedfe72c76?narHash=sha256-3KyjMPUKHkiWhwR91J1YchF6zb6gvckCAY1jOE%2Bne0U%3D' (2024-09-27)
  → 'github:serokell/deploy-rs/9c870f63e28ec1e83305f7f6cb73c941e699f74f?narHash=sha256-9I2H9x5We6Pl%2BDBYHjR1s3UT8wgwcpAH03kn9CqtdQc%3D' (2025-11-04)
• Updated input 'deploy-rs/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33?narHash=sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U%3D' (2023-10-04)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
• Updated input 'deploy-rs/utils':
    'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725?narHash=sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8%3D' (2023-12-04)
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Updated input 'nixpkgs':
    'github:serokell/nixpkgs/4fc18e4ca848c9a5b402e48d4b30155965cfce60?narHash=sha256-/3AvN4QMz/tajuU5rA2MBecUQ51Qgo73KTQT%2BskS1uE%3D' (2024-09-18)
  → 'github:serokell/nixpkgs/dfd11acd410519387b8dcda3f625fab067b1c92e?narHash=sha256-z3sUbrs%2B1h9tYgZ/9ULFIJxTzkzUAQ9iN79TZ44dgmQ%3D' (2025-11-14)
• Updated input 'serokell-nix':
    'github:serokell/serokell.nix/f8cd23e1da7a63c390c64e18921c29953bd033db?narHash=sha256-qTtZeIkG2ZyeXoNt9wuRRbcRyCLMEFkagwsLqB8Bn6A%3D' (2025-02-21)
  → 'github:serokell/serokell.nix/5a004a5e06b93ab1ba2cec1c421ed999bd8db0f3?narHash=sha256-BS8URBx5I//SnspvrnAuJAqb%2B0mOArbR73lEgRTH4i0%3D' (2025-12-10)