### PR TITLE
[Chore] Fix deploy-rs output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Deploy
-        run: nix shell -f. inputs.deploy-rs.defaultPackage.x86_64-linux -c deploy -s
+        run: nix shell -f. inputs.deploy-rs.packages.x86_64-linux.deploy-rs -c deploy -s


### PR DESCRIPTION
Problem: The deploy-rs outputs werer changed from defaultPackage to packages, so CD broke, we need to fix the ci.yaml accordingly.

Solution: Update the deploy-rs usage in the ci.yaml file to use packages instead of defaultPackage.